### PR TITLE
Add AdSense areas and cookie banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
 		<meta charset="UTF-8" />
 		<link rel="icon" type="image/svg+xml" href="/vite.svg" />
 		<meta name="generator" content="Hostinger Horizons" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Hostinger Horizons</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Hostinger Horizons</title>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-0000000000000000" crossorigin="anonymous"></script>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/src/components/CookieBanner.jsx
+++ b/src/components/CookieBanner.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const CookieBanner = () => {
+  const [visible, setVisible] = React.useState(() => !sessionStorage.getItem('cookieBannerAccepted'));
+
+  const handleAccept = () => {
+    sessionStorage.setItem('cookieBannerAccepted', 'true');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="bg-white text-gray-800 p-6 rounded-lg max-w-md text-center space-y-4">
+        <h2 className="text-lg font-semibold">Política de Cookies</h2>
+        <p className="text-sm">
+          Utilizamos cookies apenas para garantir o funcionamento do site. Nenhum dado informado é armazenado e todo conteúdo é descartado após o uso.
+        </p>
+        <button onClick={handleAccept} className="bg-blue-600 text-white px-4 py-2 rounded">Entendi</button>
+      </div>
+    </div>
+  );
+};
+
+export default CookieBanner;

--- a/src/components/GoogleAd.jsx
+++ b/src/components/GoogleAd.jsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react';
+
+const GoogleAd = ({ slot }) => {
+  useEffect(() => {
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    } catch (e) {
+      console.error(e);
+    }
+  }, []);
+
+  return (
+    <ins
+      className="adsbygoogle block my-4"
+      style={{ display: 'block' }}
+      data-ad-client="ca-pub-0000000000000000"
+      data-ad-slot={slot}
+      data-ad-format="auto"
+      data-full-width-responsive="true"
+    ></ins>
+  );
+};
+
+export default GoogleAd;

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -2,18 +2,20 @@
 import React from 'react';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
-import AdBanner from '@/components/AdBanner';
+import GoogleAd from '@/components/GoogleAd';
+import CookieBanner from '@/components/CookieBanner';
 
 const Layout = ({ children }) => {
   return (
     <div className="min-h-screen flex flex-col">
-      <AdBanner position="top" />
+      <GoogleAd slot="0000000000" />
       <Header />
-      <main className="flex-1">
+      <main className="flex-1 relative">
         {children}
+        <CookieBanner />
       </main>
       <Footer />
-      <AdBanner position="bottom" />
+      <GoogleAd slot="0000000001" />
     </div>
   );
 };

--- a/src/contexts/UserContext.jsx
+++ b/src/contexts/UserContext.jsx
@@ -16,28 +16,26 @@ export const UserProvider = ({ children }) => {
   const [documents, setDocuments] = useState([]);
 
   useEffect(() => {
-    // Carregar dados do localStorage
-    const savedUser = localStorage.getItem('user');
-    const savedDocuments = localStorage.getItem('documents');
-    
-    if (savedUser) {
-      setUser(JSON.parse(savedUser));
-    } else {
-      // Usuário padrão (free)
-      const defaultUser = {
-        id: 'user_1',
-        name: 'Usuário Demo',
-        email: 'demo@exemplo.com',
-        plan: 'free', // free ou premium
-        createdAt: new Date().toISOString()
-      };
-      setUser(defaultUser);
-      localStorage.setItem('user', JSON.stringify(defaultUser));
-    }
+    // Limpa qualquer dado persistente anterior e cria usuário padrão apenas em memória
+    localStorage.removeItem('user');
+    localStorage.removeItem('documents');
 
-    if (savedDocuments) {
-      setDocuments(JSON.parse(savedDocuments));
-    }
+    const defaultUser = {
+      id: 'user_1',
+      name: 'Usuário Demo',
+      email: 'demo@exemplo.com',
+      plan: 'free',
+      createdAt: new Date().toISOString()
+    };
+
+    setUser(defaultUser);
+
+    const handleUnload = () => {
+      setDocuments([]);
+      setUser(null);
+    };
+    window.addEventListener('beforeunload', handleUnload);
+    return () => window.removeEventListener('beforeunload', handleUnload);
   }, []);
 
   const saveDocument = (document) => {
@@ -50,29 +48,25 @@ export const UserProvider = ({ children }) => {
     
     const updatedDocuments = [...documents, newDocument];
     setDocuments(updatedDocuments);
-    localStorage.setItem('documents', JSON.stringify(updatedDocuments));
-    
+
     return newDocument;
   };
 
   const updateDocument = (documentId, updates) => {
-    const updatedDocuments = documents.map(doc => 
+    const updatedDocuments = documents.map(doc =>
       doc.id === documentId ? { ...doc, ...updates, updatedAt: new Date().toISOString() } : doc
     );
     setDocuments(updatedDocuments);
-    localStorage.setItem('documents', JSON.stringify(updatedDocuments));
   };
 
   const deleteDocument = (documentId) => {
     const updatedDocuments = documents.filter(doc => doc.id !== documentId);
     setDocuments(updatedDocuments);
-    localStorage.setItem('documents', JSON.stringify(updatedDocuments));
   };
 
   const upgradeToPremium = () => {
     const updatedUser = { ...user, plan: 'premium' };
     setUser(updatedUser);
-    localStorage.setItem('user', JSON.stringify(updatedUser));
   };
 
   const value = {


### PR DESCRIPTION
## Summary
- add Google AdSense script in HTML
- create GoogleAd component for ad slots
- create CookieBanner component to show cookie policy on first visit
- show AdSense banners and cookie banner in layout
- clear persistent storage and purge data in user context

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865bebacd048328aee0c6d8514d85fd

## Resumo por Sourcery

Integra anúncios do Google AdSense e um banner de consentimento de cookies no layout, e simplifica o contexto do usuário desativando o armazenamento persistente e limpando o estado ao fazer o unload.

Novos Recursos:
- Adiciona o componente `GoogleAd` para espaços de anúncios do AdSense
- Adiciona o componente `CookieBanner` para exibir um banner de consentimento de cookies na primeira visita
- Incorpora o script do Google AdSense em index.html e coloca anúncios no layout do site

Melhorias:
- Refatora o `UserContext` para remover a persistência do `localStorage` e limpar os dados de usuário/documentos ao fazer o unload da página

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Google AdSense ads and a cookie consent banner into the layout, and simplify user context by disabling persistent storage and clearing state on unload.

New Features:
- Add GoogleAd component for AdSense ad slots
- Add CookieBanner component to display a cookie consent banner on first visit
- Embed Google AdSense script in index.html and place ads in the site layout

Enhancements:
- Refactor UserContext to remove localStorage persistence and clear user/documents data on page unload

</details>