### PR TITLE
Implement daily document generation limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Este projeto é um gerador de documentos legais como Política de Privacidade, T
 ## Funcionalidades
 
 - Cria documentos legais em conformidade com a LGPD e outras legislações.
-- Armazena dados somente em memória: nenhuma informação fornecida é gravada de forma permanente no navegador.
+- Armazena dados apenas temporariamente em memória e no `localStorage` para controle de uso. Nenhuma informação de documentos é mantida após o término da sessão.
+- Limita a geração a 5 documentos por endereço IP a cada período de 24 horas.
 - Banner de cookies exibido na primeira visita informando que os dados são descartados após o uso.
 - Espaços reservados para banners do Google AdSense no topo e no rodapé.
 

--- a/src/lib/rateLimiter.js
+++ b/src/lib/rateLimiter.js
@@ -1,0 +1,59 @@
+export const MAX_DOCS_PER_DAY = 5;
+const STORAGE_KEY = 'doc_generation_records';
+
+async function fetchIp() {
+  try {
+    const response = await fetch('https://api.ipify.org?format=json');
+    const data = await response.json();
+    return data.ip;
+  } catch (error) {
+    console.error('IP fetch failed', error);
+    return null;
+  }
+}
+
+function loadRecords() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+  } catch (e) {
+    return {};
+  }
+}
+
+function saveRecords(records) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+}
+
+export async function canGenerate() {
+  const ip = await fetchIp();
+  if (!ip) {
+    return true;
+  }
+  const records = loadRecords();
+  const now = Date.now();
+
+  if (!records[ip] || now - records[ip].timestamp > 24 * 60 * 60 * 1000) {
+    records[ip] = { count: 0, timestamp: now };
+    saveRecords(records);
+    return true;
+  }
+
+  return records[ip].count < MAX_DOCS_PER_DAY;
+}
+
+export async function recordGeneration() {
+  const ip = await fetchIp();
+  if (!ip) {
+    return;
+  }
+  const records = loadRecords();
+  const now = Date.now();
+
+  if (!records[ip] || now - records[ip].timestamp > 24 * 60 * 60 * 1000) {
+    records[ip] = { count: 1, timestamp: now };
+  } else {
+    records[ip].count += 1;
+  }
+
+  saveRecords(records);
+}


### PR DESCRIPTION
## Summary
- add new rate limiter logic to track document generation per IP
- enforce limit in Generator page
- document limit in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686734c6248c8328bfafa9f94aadf05a

## Resumo por Sourcery

Implementa um limite diário de geração de documentos por IP, adicionando um módulo de rate limiter, aplicando-o na UI do Generator e atualizando a documentação de acordo.

Novas Funcionalidades:
- Introduz um módulo de rate limiter com `canGenerate`, `recordGeneration` e `MAX_DOCS_PER_DAY` para rastrear o uso por IP em um período de 24 horas
- Aplica um limite de 5 gerações de documentos por IP em 24 horas na página do Generator

Melhorias:
- Exibe uma notificação toast destrutiva quando o limite diário de geração é atingido
- Registra cada geração de documento bem-sucedida para atualizar as contagens de uso

Documentação:
- Atualiza o README para incluir detalhes do rate limit e esclarecer o tratamento temporário de dados em memória/localStorage

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a daily document generation limit per IP by adding a rate limiter module, enforcing it in the Generator UI, and updating documentation accordingly.

New Features:
- Introduce a rate limiter module with canGenerate, recordGeneration, and MAX_DOCS_PER_DAY to track usage per IP over a 24h window
- Enforce a limit of 5 document generations per IP in 24 hours on the Generator page

Enhancements:
- Display a destructive toast notification when the daily generation limit is reached
- Record each successful document generation to update usage counts

Documentation:
- Update README to include rate limit details and clarify temporary in-memory/localStorage data handling

</details>