### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+dist
+.DS_Store
+.git
+.gitignore
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Multi-stage Dockerfile for Gerador de Termos e Políticas
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:stable-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Os valores de `data-ad-client` e `data-ad-slot` nos componentes de anúncio pode
 - `src/pages`: páginas principais do aplicativo.
 - `public` e `index.html`: arquivos estáticos e ponto de entrada da aplicação.
 
+## Docker
+
+Para construir a imagem de produção e executá-la localmente:
+
+```bash
+docker build -t gerador-termos .
+docker run -p 8080:80 gerador-termos
+```
+
+A aplicação ficará disponível em `http://localhost:8080`.
 ## Licença
 
 Este projeto é distribuído sem garantia de suporte ou manutenção. Utilize-o conforme sua necessidade.


### PR DESCRIPTION
## Summary
- add Dockerfile with multi-stage build
- exclude build artifacts with .dockerignore
- document Docker usage in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68687bfc63d48328961c04254742f6d2

## Resumo por Sourcery

Habilita o suporte ao Docker introduzindo um Dockerfile de construção multi-estágio, adicionando um .dockerignore e atualizando o README com os passos de utilização.

Novas Funcionalidades:
- Adiciona Dockerfile multi-estágio e .dockerignore para contentorizar a aplicação

Documentação:
- Documenta as instruções de construção e execução do Docker no README

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Docker support by introducing a multi-stage build Dockerfile, adding a .dockerignore, and updating the README with usage steps.

New Features:
- Add multi-stage Dockerfile and .dockerignore to containerize the application

Documentation:
- Document Docker build and run instructions in README

</details>